### PR TITLE
Fix invalid appDir when overriden by user config

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,11 +107,18 @@ function toRoutesDirEntries(
   return entries
 }
 
-function resolveBaseDirFor(routesDir: RoutesDirInput | undefined): string {
-  const base =
-    routesDir === undefined || typeof routesDir === 'string' ? 'app' : '.'
+// inspired by @react-router/dev/routes
+function getRootDirectory(): string {
+  return process.cwd();
+}
 
-  return path.isAbsolute(base) ? base : path.resolve(process.cwd(), base)
+// inspired by @react-router/dev/routes
+function getAppDirectory(): string {
+  return (globalThis as any).__reactRouterAppDirectory ?? path.resolve(getRootDirectory(), 'app');
+}
+
+function resolveBaseDirFor(routesDir: RoutesDirInput | undefined): string {
+  return (routesDir === undefined || typeof routesDir === 'string') ? getAppDirectory() : getRootDirectory();
 }
 
 export function normalizeRoutesDirOption(
@@ -145,13 +152,8 @@ export function normalizeRoutesDirOption(
     }
   })
 
-  const rootEntry = entries.find((entry) => entry.mountPath === '/')
-  const appDir = rootEntry
-    ? path.dirname(rootEntry.fsDir)
-    : path.resolve(process.cwd(), 'app')
-
   return entries.map((entry) => {
-    const relativeImport = path.relative(appDir, entry.fsDir) || '.'
+    const relativeImport = path.relative(getAppDirectory(), entry.fsDir) || '.'
     const normalizedImport = relativeImport.split(path.sep).join('/')
 
     return {


### PR DESCRIPTION
- appDir can be changed in react-router config file (ex: "app/router")
- routes can be loaded outside of specified dir (ex: "../pages/home.tsx")

auto-routes didn't handle that well

---

I wanted to add a test case, but I don't know how to mock a given react-router.config file